### PR TITLE
Incorrect condition checking in HID.h

### DIFF
--- a/libraries/HID/HID.h
+++ b/libraries/HID/HID.h
@@ -23,7 +23,7 @@
 #include <Arduino.h>
 #include "USB/PluggableUSB.h"
 
-#if !defined(CDC_HID) || !defined(HID_ONLY) || !defined(WITH_CDC)
+#if !defined(CDC_HID) && !defined(HID_ONLY) && !defined(WITH_CDC)
 #error Please select CDC_HID, HID_ONLY, or WITH_CDC in the Tools->USB menu.
 #endif
 


### PR DESCRIPTION
I found an incorrect checking of the -D macros which prevents the compilation of a project with USD enabled. The compilation should stop with #error only if none of the macros are defined. The condition, as it was written previously, prevents compiling a project with USB enabled.